### PR TITLE
docs(#3): CONTRIBUTING.md에 브랜치 전략 추가

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,27 @@ docs(#125): AGENTS.md 응답 규칙 정리
 
 - 허용 `type`: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `build`, `perf`, `revert`
 
-## 3) PR 규칙
+## 3) 브랜치 전략
+
+- 브랜치는 이슈 단위로 생성한다.
+- 네이밍 형식:
+
+```text
+<prefix>/#<issue_number>/<summary>
+```
+
+- `prefix`는 커밋 `type`과 동일하게 사용한다 (`feat`, `fix`, `docs`, `chore` 등).
+- 예시:
+
+```text
+feat/#3/add-filter-logic
+fix/#12/income-boundary-error
+docs/#5/update-contributing
+```
+
+- `main` 브랜치에 직접 커밋하지 않는다. 반드시 PR을 통해 병합한다.
+
+## 4) PR 규칙
 
 - PR은 하나 이상의 이슈를 반드시 연결한다.
 - PR 제목/본문은 한국어로 작성한다.
@@ -40,14 +60,15 @@ docs(#125): AGENTS.md 응답 규칙 정리
 - 테스트/검증 결과
 - 영향 범위(있다면)
 
-## 4) 권장 작업 흐름
+## 5) 권장 작업 흐름
 
 1. 이슈 생성
 2. 구현 계획 수립(필요 시 `docs/plans/`에 문서화)
-3. 이슈 번호를 scope로 커밋
-4. PR 생성 후 이슈 연결
+3. 이슈 번호로 브랜치 생성: `git checkout -b <prefix>/#<issue_number>/<summary>`
+4. 이슈 번호를 scope로 커밋
+5. PR 생성 후 이슈 연결
 
-## 5) 자동 검증
+## 6) 자동 검증
 
 - 저장소는 `.github/workflows/commitlint.yml`로 커밋 메시지를 검사한다.
 - 로컬에서도 아래처럼 사전 확인할 수 있다.


### PR DESCRIPTION
## 변경 목적

브랜치 네이밍 규칙이 CONTRIBUTING.md에 없어 협업 기준이 불완전했음. 브랜치 전략 섹션 추가.

## 핵심 변경점

- 3) 브랜치 전략 섹션 신규 추가
  - 네이밍 형식: `<prefix>/#<issue_number>/<summary>`
  - `main` 직접 커밋 금지 명시
- 4) 권장 작업 흐름에 브랜치 생성 단계 추가
- 기존 섹션 번호 일괄 조정 (3→4, 4→5, 5→6)

## 테스트/검증 결과

- 이 PR 자체가 브랜치 전략(`docs/#3/add-branch-strategy`)을 따라 작성됨

## 영향 범위

문서 변경만. 코드 영향 없음.

Closes #3