### PR TITLE
fix(#20): 코드 리뷰 지적 사항 해소 (정규식 보강·자동차 판정·테스트·주석)

### DIFF
--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -19,6 +19,12 @@ export interface UserProfile {
   districts: string[];           // 선호 구 단위 (소프트 필터, 예: ["송파구", "관악구"])
   maxDeposit: number;            // 보증금 최대 (만원, 0이면 필터 안 함)
   maxRent: number;               // 월임대료 최대 (만원, 0이면 필터 안 함)
+  /**
+   * 특별공급 신청 트랙.
+   * 현재는 env-setup에서 수집하고 app-config에서 읽지만 필터/판정 로직에서 미사용.
+   * TODO: 추후 특별공급 유형별 자격 필터에 활용 예정
+   * @see https://github.com/YOOGOMJA/find-my-housing-plan/issues/20
+   */
   applicantGroup:
     | "general"
     | "youth"

--- a/src/features/filter-notices/filter-notices.test.ts
+++ b/src/features/filter-notices/filter-notices.test.ts
@@ -247,4 +247,34 @@ describe("자격 판정 (buildEligibilityChecks)", () => {
     const sub = checks.find((c) => c.label === "청약통장");
     expect(sub?.result).toBe("pass");
   });
+
+  it("자동차 자산 통과 케이스", () => {
+    const notice = {
+      ...baseNotice,
+      conditions: { ...baseNotice.conditions, carAssetLimit: "자동차 3,683만원 이하" },
+    };
+    const checks = buildEligibilityChecks(notice, { ...baseUser, carAsset: 3000 });
+    const car = checks.find((c) => c.label === "자동차");
+    expect(car?.result).toBe("pass");
+  });
+
+  it("자동차 자산 초과 케이스", () => {
+    const notice = {
+      ...baseNotice,
+      conditions: { ...baseNotice.conditions, carAssetLimit: "자동차 3,683만원 이하" },
+    };
+    const checks = buildEligibilityChecks(notice, { ...baseUser, carAsset: 4000 });
+    const car = checks.find((c) => c.label === "자동차");
+    expect(car?.result).toBe("fail");
+  });
+
+  it("자동차 기준 파싱 불가 시 unknown", () => {
+    const notice = {
+      ...baseNotice,
+      conditions: { ...baseNotice.conditions, carAssetLimit: "자동차 기준 별도 문의" },
+    };
+    const checks = buildEligibilityChecks(notice, baseUser);
+    const car = checks.find((c) => c.label === "자동차");
+    expect(car?.result).toBe("unknown");
+  });
 });

--- a/src/features/filter-notices/model/filter-notices.ts
+++ b/src/features/filter-notices/model/filter-notices.ts
@@ -299,6 +299,9 @@ export function filterNotices(notices: ParsedNotice[], user: UserProfile): Parse
       matchesHousingPreference(notice, user) &&
       matchesPrice(notice, user) &&
       matchesNoticeEligibility(notice, user),
-    // matchesDistrict는 소프트 필터 → 제외가 아닌 메시지에서 강조
+    // matchesDistrict는 소프트 필터 — 하드 필터로 제외하지 않음.
+    // TODO: 선호 구 포함 공고를 상단 정렬하는 기능 미구현.
+    //       현재는 formatSlackMessage에서 "[선호지역]" 강조 표시만 적용됨.
+    //       @see https://github.com/YOOGOMJA/find-my-housing-plan/issues/20
   );
 }

--- a/src/features/filter-notices/model/filter-notices.ts
+++ b/src/features/filter-notices/model/filter-notices.ts
@@ -278,6 +278,18 @@ export function buildEligibilityChecks(notice: ParsedNotice, user: UserProfile):
     });
   }
 
+  // 자동차 자산 판정
+  if (notice.conditions.carAssetLimit) {
+    const limit = parseAssetLimit(notice.conditions.carAssetLimit);
+    const result: EligibilityResult = limit === null ? "unknown" : user.carAsset <= limit ? "pass" : "fail";
+    checks.push({
+      label: "자동차",
+      result,
+      rawCondition: notice.conditions.carAssetLimit,
+      userValue: `${user.carAsset}만원`,
+    });
+  }
+
   return checks;
 }
 

--- a/src/features/parse-notice/model/parse-notices.ts
+++ b/src/features/parse-notice/model/parse-notices.ts
@@ -154,8 +154,9 @@ export function parseAmountToManwon(text: string | null | undefined): number | n
   }
 
   if (!matched) {
-    // "8,671,000원" 형태 (원 단위) → 만원으로 변환
-    const wonMatch = text.match(/([\d,]+)\s*원/);
+    // 순수 원 단위 표기 처리: "8,671,000원" → 만원 변환
+    // 부정 후방 탐색으로 "만원"·"억원"의 "원" 부분에는 매치되지 않도록 보장
+    const wonMatch = text.match(/(?<![만억])([\d,]+)\s*원/);
     if (wonMatch) {
       const won = parseFloat(wonMatch[1].replace(/,/g, ""));
       if (isFinite(won)) { return won / 10000; }

--- a/src/features/parse-notice/parse-notice.test.ts
+++ b/src/features/parse-notice/parse-notice.test.ts
@@ -64,6 +64,28 @@ describe("buildClaudePrompt 출력에서 신규 필드 파싱", () => {
     const result = parseAmountToManwon("1억 2,000만원");
     expect(result).toBe(12000);
   });
+
+  it("만원이 포함된 복합 문자열에서도 순수 원 단위를 잡는다", () => {
+    // 복합 문자열 케이스: 만원 매치 후에도 별도 원 단위가 존재하지 않으므로 만원 결과 반환
+    const result = parseAmountToManwon("임대보증금 8,671,000원");
+    expect(result).toBe(867.1);
+  });
+
+  it("만원 표기에서 원 단위로 오파싱하지 않는다", () => {
+    // "8,000만원" → manMatch가 잡으므로 wonMatch가 개입하지 않아야 함
+    const result = parseAmountToManwon("8,000만원");
+    expect(result).toBe(8000);
+  });
+
+  it("억+만원 복합 표기에서 순수 원 단위를 혼동하지 않는다", () => {
+    const result = parseAmountToManwon("1억 2,000만원");
+    expect(result).toBe(12000);
+  });
+
+  it("순수 원 단위에서 만원 접미어가 없으면 정상 변환한다", () => {
+    const result = parseAmountToManwon("145,630원");
+    expect(result).toBeCloseTo(14.563, 2);
+  });
 });
 
 describe("buildClaudePrompt", () => {

--- a/src/features/parse-notice/parse-notice.test.ts
+++ b/src/features/parse-notice/parse-notice.test.ts
@@ -71,17 +71,6 @@ describe("buildClaudePrompt 출력에서 신규 필드 파싱", () => {
     expect(result).toBe(867.1);
   });
 
-  it("만원 표기에서 원 단위로 오파싱하지 않는다", () => {
-    // "8,000만원" → manMatch가 잡으므로 wonMatch가 개입하지 않아야 함
-    const result = parseAmountToManwon("8,000만원");
-    expect(result).toBe(8000);
-  });
-
-  it("억+만원 복합 표기에서 순수 원 단위를 혼동하지 않는다", () => {
-    const result = parseAmountToManwon("1억 2,000만원");
-    expect(result).toBe(12000);
-  });
-
   it("순수 원 단위에서 만원 접미어가 없으면 정상 변환한다", () => {
     const result = parseAmountToManwon("145,630원");
     expect(result).toBeCloseTo(14.563, 2);

--- a/src/features/parse-notice/parse-notice.test.ts
+++ b/src/features/parse-notice/parse-notice.test.ts
@@ -65,8 +65,8 @@ describe("buildClaudePrompt 출력에서 신규 필드 파싱", () => {
     expect(result).toBe(12000);
   });
 
-  it("만원이 포함된 복합 문자열에서도 순수 원 단위를 잡는다", () => {
-    // 복합 문자열 케이스: 만원 매치 후에도 별도 원 단위가 존재하지 않으므로 만원 결과 반환
+  it("한글 접두어가 있는 순수 원 단위 표기를 변환한다", () => {
+    // manMatch·eokMatch 모두 미매치 → wonMatch 경로: 8,671,000원 → 867.1만원
     const result = parseAmountToManwon("임대보증금 8,671,000원");
     expect(result).toBe(867.1);
   });

--- a/src/shared/config/app-config.test.ts
+++ b/src/shared/config/app-config.test.ts
@@ -31,6 +31,10 @@ describe("loadConfig", () => {
     process.env.USER_MAX_AREA = "60";
     process.env.USER_MIN_BUILD_YEAR = "2010";
     process.env.USER_HOUSING_TYPES = "06,13";
+    process.env.USER_DISTRICTS = "송파구,관악구";
+    process.env.USER_MAX_DEPOSIT = "15000";
+    process.env.USER_MAX_RENT = "50";
+    process.env.USER_APPLICANT_GROUP = "youth";
 
     const config = loadConfig();
     expect(config.apiKey).toBe("test-api-key");
@@ -38,6 +42,10 @@ describe("loadConfig", () => {
     expect(config.user.regions).toEqual(["11", "41"]);
     expect(config.user.housingTypes).toEqual(["06", "13"]);
     expect(config.user.maritalStatus).toBe("single");
+    expect(config.user.districts).toEqual(["송파구", "관악구"]);
+    expect(config.user.maxDeposit).toBe(15000);
+    expect(config.user.maxRent).toBe(50);
+    expect(config.user.applicantGroup).toBe("youth");
   });
 
   it("필수 환경변수 누락 시 오류를 던진다", () => {
@@ -52,5 +60,45 @@ describe("loadConfig", () => {
     process.env.USER_AGE = "abc";
 
     expect(() => loadConfig()).toThrow("USER_AGE");
+  });
+
+  describe("신규 사용자 env 필드", () => {
+    beforeEach(() => {
+      process.env.PUBLIC_DATA_API_KEY = "test-key";
+      process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+      process.env.SLACK_WEBHOOK_URL = "https://hooks.slack.com/test";
+      process.env.USER_AGE = "30";
+    });
+
+    it("USER_DISTRICTS 미설정 시 빈 배열", () => {
+      delete process.env.USER_DISTRICTS;
+      const config = loadConfig();
+      expect(config.user.districts).toEqual([]);
+    });
+
+    it("USER_MAX_DEPOSIT 미설정 시 0", () => {
+      delete process.env.USER_MAX_DEPOSIT;
+      const config = loadConfig();
+      expect(config.user.maxDeposit).toBe(0);
+    });
+
+    it("USER_MAX_RENT 미설정 시 0", () => {
+      delete process.env.USER_MAX_RENT;
+      const config = loadConfig();
+      expect(config.user.maxRent).toBe(0);
+    });
+
+    it("USER_APPLICANT_GROUP 유효하지 않은 값은 null 반환", () => {
+      process.env.USER_APPLICANT_GROUP = "invalid-group";
+      const config = loadConfig();
+      expect(config.user.applicantGroup).toBeNull();
+    });
+
+    it("USER_APPLICANT_GROUP 미설정 시 general 기본값", () => {
+      delete process.env.USER_APPLICANT_GROUP;
+      const config = loadConfig();
+      // "general"은 유효한 값이므로 그대로 반환
+      expect(config.user.applicantGroup).toBe("general");
+    });
   });
 });

--- a/src/shared/config/app-config.test.ts
+++ b/src/shared/config/app-config.test.ts
@@ -68,6 +68,7 @@ describe("loadConfig", () => {
       process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
       process.env.SLACK_WEBHOOK_URL = "https://hooks.slack.com/test";
       process.env.USER_AGE = "30";
+      process.env.USER_MARITAL_STATUS = "single";
     });
 
     it("USER_DISTRICTS 미설정 시 빈 배열", () => {


### PR DESCRIPTION
## 요약

필터 강화 및 메시지 개선(#18) 코드 리뷰에서 발견된 4가지 이슈를 해소합니다.

- `parseAmountToManwon` wonMatch에 부정 후방 탐색(`(?<![만억])`) 추가로 "만원"·"억원"의 "원" 오매치 방지
- `buildEligibilityChecks`에 자동차 자산 판정 블록 추가 (`matchesNoticeEligibility`와 일관성 확보)
- `app-config.test.ts`에 신규 env 필드(districts·maxDeposit·maxRent·applicantGroup) 검증 테스트 5개 추가
- `applicantGroup` 미사용 JSDoc 및 `filterNotices` 소프트 필터 정렬 미구현 TODO 주석 명시

Closes #20

## 테스트 플랜

- [x] `npx jest parse-notice` — 15개 통과 (신규 2개 포함)
- [x] `npx jest filter-notices` — 31개 통과 (신규 3개 포함)
- [x] `npx jest app-config` — 8개 통과 (신규 5개 포함)
- [x] `npx jest` — 전체 96개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)