### PR TITLE
fix(#22): 진행 출력 중복 제거 및 바 영역 스피너 추가

### DIFF
--- a/src/shared/lib/progress-reporter.test.ts
+++ b/src/shared/lib/progress-reporter.test.ts
@@ -61,5 +61,65 @@ describe("createProgressReporter", () => {
 
     expect(logged.some((line) => line.startsWith("전체 ["))).toBe(true);
     expect(logged.some((line) => line.startsWith("현재 [수집]"))).toBe(true);
+    expect(logged.some((line) => /현재 \[[|\/\\-] /.test(line))).toBe(false);
+  });
+
+  it("TTY 환경에서 현재 라인에 스피너를 표시한다", () => {
+    const writes: string[] = [];
+    const writeSpy = jest.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+      return true;
+    });
+
+    withTty(true, () => {
+      const reporter = createProgressReporter();
+      reporter.report({ phase: "collect", current: 1, total: 2, percent: 50, message: "수집 1/2" });
+      reporter.flush();
+    });
+
+    writeSpy.mockRestore();
+
+    const output = writes.join("");
+    expect(/현재 \[[|\/\\-] 수집\]/.test(output)).toBe(true);
+  });
+
+  it("TTY 환경에서 전체 바 라인 끝에 스피너를 표시한다", () => {
+    const writes: string[] = [];
+    const writeSpy = jest.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+      return true;
+    });
+
+    withTty(true, () => {
+      const reporter = createProgressReporter();
+      reporter.report({ phase: "collect", current: 1, total: 2, percent: 50, message: "수집 1/2" });
+      reporter.flush();
+    });
+
+    writeSpy.mockRestore();
+
+    const output = writes.join("");
+    expect(/전체 \[[^\]]+\] \d+% [|\/\\-]/.test(output)).toBe(true);
+  });
+
+  it("마지막 이벤트가 완료 상태면 complete에서 중복 출력하지 않는다", () => {
+    const writes: string[] = [];
+    const writeSpy = jest.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+      return true;
+    });
+
+    withTty(true, () => {
+      const reporter = createProgressReporter();
+      reporter.report({ phase: "notify", current: 4, total: 4, percent: 100, message: "Slack 전송 4/4" });
+      reporter.complete();
+      reporter.flush();
+    });
+
+    writeSpy.mockRestore();
+
+    const output = writes.join("");
+    const occurrences = output.split("Slack 전송 4/4").length - 1;
+    expect(occurrences).toBe(1);
   });
 });

--- a/src/shared/lib/progress-reporter.ts
+++ b/src/shared/lib/progress-reporter.ts
@@ -8,10 +8,12 @@ export function createProgressReporter(): { report: ProgressReporter; flush: () 
     notify: "전송",
   };
   const phaseOrder: ProgressPhase[] = ["collect", "parse", "notify"];
+  const spinnerFrames = ["|", "/", "-", "\\"];
   const barWidth = 20;
 
   let hasRendered = false;
   let lastEvent: ProgressEvent | null = null;
+  let spinnerIndex = 0;
 
   const clampPercent = (value: number): number => {
     if (!Number.isFinite(value)) {
@@ -32,7 +34,10 @@ export function createProgressReporter(): { report: ProgressReporter; flush: () 
   };
 
   const renderLines = (overallPercent: number, currentLine: string): void => {
-    const overallLine = `전체 [${makeBar(overallPercent)}] ${clampPercent(overallPercent)}%`;
+    const spinner = spinnerFrames[spinnerIndex % spinnerFrames.length];
+    const overallLine = isTty
+      ? `전체 [${makeBar(overallPercent)}] ${clampPercent(overallPercent)}% ${spinner}`
+      : `전체 [${makeBar(overallPercent)}] ${clampPercent(overallPercent)}%`;
 
     if (!isTty) {
       console.log(overallLine);
@@ -57,15 +62,37 @@ export function createProgressReporter(): { report: ProgressReporter; flush: () 
     hasRendered = false;
   };
 
+  const formatCurrentLine = (event: ProgressEvent): string => {
+    const percent = clampPercent(event.percent);
+    if (!isTty) {
+      return `현재 [${phaseLabel[event.phase]}] ${event.message} (${event.current}/${event.total}, ${percent}%)`;
+    }
+
+    const frame = spinnerFrames[spinnerIndex % spinnerFrames.length];
+    return `현재 [${frame} ${phaseLabel[event.phase]}] ${event.message} (${event.current}/${event.total}, ${percent}%)`;
+  };
+
+  const isCompletedEvent = (event: ProgressEvent): boolean => {
+    if (clampPercent(event.percent) >= 100) {
+      return true;
+    }
+    return event.total > 0 && event.current >= event.total;
+  };
+
   const report = (event: ProgressEvent): void => {
-    const currentLine = `현재 [${phaseLabel[event.phase]}] ${event.message} (${event.current}/${event.total}, ${clampPercent(
-      event.percent,
-    )}%)`;
+    const currentLine = formatCurrentLine(event);
     renderLines(toOverallPercent(event), currentLine);
+    if (isTty) {
+      spinnerIndex = (spinnerIndex + 1) % spinnerFrames.length;
+    }
     lastEvent = event;
   };
 
   const complete = (): void => {
+    if (lastEvent && isCompletedEvent(lastEvent)) {
+      return;
+    }
+
     const currentLine = lastEvent
       ? `현재 [${phaseLabel[lastEvent.phase]}] ${lastEvent.message} (100%)`
       : "현재 [완료] 파이프라인 완료 (100%)";


### PR DESCRIPTION
## 변경 목적
진행 로그의 최종 100% 중복 출력 문제를 해결하고, TTY 콘솔에서 진행감이 보이도록 스피너를 추가합니다.

## 핵심 변경점
- `complete()`에서 마지막 이벤트가 이미 완료 상태면 중복 출력 생략
- TTY 환경에서 `전체 [bar]` 라인 끝에 스피너 표시
- TTY 환경에서 `현재` 라인 앞 스피너 유지
- non-TTY 환경에서는 기존 텍스트 로그 형식 유지
- 진행 출력 테스트 3건 보강(바 스피너, non-TTY 스피너 미출력, 완료 중복 방지)

## 테스트/검증
- `npx jest src/shared/lib/progress-reporter.test.ts` 통과 (5/5)

## 이슈
- Closes #22
