### PR TITLE
fix(#26): TTY 스피너 주기 갱신 및 테스트 보강

### DIFF
--- a/src/shared/lib/progress-reporter.test.ts
+++ b/src/shared/lib/progress-reporter.test.ts
@@ -122,6 +122,29 @@ describe("createProgressReporter", () => {
     expect(/전체 \[[^\]]+\] \d+% [|\/\\-]/.test(output)).toBe(true);
   });
 
+  it("TTY 환경에서 스피너가 1초마다 회전한다", () => {
+    jest.useFakeTimers();
+    const writes: string[] = [];
+    const writeSpy = jest.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+      return true;
+    });
+
+    withTty(true, () => {
+      const reporter = createProgressReporter();
+      reporter.report({ phase: "collect", current: 1, total: 2, percent: 50, message: "수집 1/2" });
+      jest.advanceTimersByTime(1000);
+      reporter.flush();
+    });
+
+    writeSpy.mockRestore();
+    jest.useRealTimers();
+
+    const output = writes.join("");
+    expect(output).toContain("% |");
+    expect(output).toContain("% /");
+  });
+
   it("마지막 이벤트가 완료 상태면 complete에서 중복 출력하지 않는다", () => {
     const writes: string[] = [];
     const writeSpy = jest.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {

--- a/src/shared/lib/progress-reporter.ts
+++ b/src/shared/lib/progress-reporter.ts
@@ -17,7 +17,9 @@ export function createProgressReporter(): { report: ProgressReporter; flush: () 
   let hasRendered = false;
   let lastEvent: ProgressEvent | null = null;
   let lastOverallPercent: number | null = null;
+  let lastCurrentLine: string | null = null;
   let spinnerIndex = 0;
+  let spinnerTimer: ReturnType<typeof setInterval> | null = null;
 
   const clampPercent = (value: number): number => {
     if (!Number.isFinite(value)) {
@@ -50,6 +52,9 @@ export function createProgressReporter(): { report: ProgressReporter; flush: () 
       return;
     }
 
+    lastOverallPercent = clampPercent(overallPercent);
+    lastCurrentLine = currentLine;
+
     if (hasRendered) {
       process.stdout.write(`\u001B[1A\r\u001B[2K${overallLine}\n\r\u001B[2K${currentLine}`);
       return;
@@ -57,13 +62,35 @@ export function createProgressReporter(): { report: ProgressReporter; flush: () 
 
     process.stdout.write(`${overallLine}\n${currentLine}`);
     hasRendered = true;
-    lastOverallPercent = clampPercent(overallPercent);
+  };
+
+  const stopSpinnerTimer = (): void => {
+    if (!spinnerTimer) {
+      return;
+    }
+    clearInterval(spinnerTimer);
+    spinnerTimer = null;
+  };
+
+  const startSpinnerTimer = (): void => {
+    if (!isTty || spinnerTimer) {
+      return;
+    }
+
+    spinnerTimer = setInterval(() => {
+      if (!hasRendered || lastOverallPercent === null || !lastCurrentLine) {
+        return;
+      }
+      spinnerIndex = (spinnerIndex + 1) % spinnerFrames.length;
+      renderLines(lastOverallPercent, lastCurrentLine);
+    }, 1000);
   };
 
   const flush = (): void => {
     if (!isTty || !hasRendered) {
       return;
     }
+    stopSpinnerTimer();
     process.stdout.write("\n");
     hasRendered = false;
   };
@@ -76,9 +103,7 @@ export function createProgressReporter(): { report: ProgressReporter; flush: () 
   const report = (event: ProgressEvent): void => {
     const currentLine = formatCurrentLine(event);
     renderLines(toOverallPercent(event), currentLine);
-    if (isTty) {
-      spinnerIndex = (spinnerIndex + 1) % spinnerFrames.length;
-    }
+    startSpinnerTimer();
     lastEvent = event;
   };
 


### PR DESCRIPTION
## 변경 목적
TTY 환경에서 진행률 출력이 정지된 것처럼 보이지 않도록 스피너 갱신 동작을 개선합니다.

## 핵심 변경점
- `progress-reporter`에 스피너 주기 갱신 타이머 추가(1초 주기)
- flush 시 타이머 정리 로직 추가
- TTY 환경에서 스피너가 시간 경과에 따라 회전하는 테스트 추가

## 테스트/검증 결과
- `npx jest src/shared/lib/progress-reporter.test.ts` 통과 (7 passed)

## 영향 범위
- `src/shared/lib/progress-reporter.ts`
- `src/shared/lib/progress-reporter.test.ts`

Closes #26
