### PR TITLE
feat: LH 공급정보 파싱/알림 가시성/재처리 모드 개선 (#28)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -153,3 +153,28 @@ USER_MAX_RENT=0
 # 설명: 특별공급 신청 트랙
 # 예시: youth
 USER_APPLICANT_GROUP=general
+
+# [재처리 모드]
+# REPROCESS_ENABLED
+# 타입: enum(true|false)
+# 설명: true면 기처리 상태를 무시하고 최근 기간 공고를 재처리
+# 예시: false
+REPROCESS_ENABLED=false
+
+# REPROCESS_DRY_RUN
+# 타입: enum(true|false)
+# 설명: true면 Slack 전송/상태 저장 없이 건수만 점검
+# 예시: true
+REPROCESS_DRY_RUN=false
+
+# REPROCESS_LOOKBACK_MONTHS
+# 타입: number
+# 설명: 재처리 대상 조회 기간(개월)
+# 예시: 6
+REPROCESS_LOOKBACK_MONTHS=6
+
+# REPROCESS_MAX_NOTIFICATIONS
+# 타입: number
+# 설명: 한 번 실행에서 Slack 전송 최대 건수(조건충족+수동확인 합산)
+# 예시: 50
+REPROCESS_MAX_NOTIFICATIONS=50

--- a/src/app/main.test.ts
+++ b/src/app/main.test.ts
@@ -1,5 +1,5 @@
 import { Notice } from "../entities/notice";
-import { selectProcessedNotices } from "./main";
+import { buildCollectOptions, isReprocessDryRunMode, selectProcessedNotices } from "./main";
 
 const baseNotice = (panId: string): Notice => ({
   panId,
@@ -35,5 +35,38 @@ describe("selectProcessedNotices", () => {
 
     const result = selectProcessedNotices(notices, candidates, new Set(["B"]));
     expect(result.map((notice) => notice.panId)).toEqual(["A", "B"]);
+  });
+});
+
+describe("isReprocessDryRunMode", () => {
+  it("재처리 모드 + dry-run일 때만 true", () => {
+    expect(isReprocessDryRunMode(true, true)).toBe(true);
+    expect(isReprocessDryRunMode(false, true)).toBe(false);
+    expect(isReprocessDryRunMode(true, false)).toBe(false);
+  });
+});
+
+describe("buildCollectOptions", () => {
+  const performance = {
+    collectConcurrency: 4,
+    httpKeepAlive: true,
+  };
+
+  it("일반 모드에서는 lookbackMonths를 전달하지 않는다", () => {
+    const options = buildCollectOptions(false, performance, 3);
+    expect(options).toEqual({
+      concurrency: 4,
+      keepAlive: true,
+    });
+    expect("lookbackMonths" in options).toBe(false);
+  });
+
+  it("재처리 모드에서는 lookbackMonths를 전달한다", () => {
+    const options = buildCollectOptions(true, performance, 3);
+    expect(options).toEqual({
+      concurrency: 4,
+      keepAlive: true,
+      lookbackMonths: 3,
+    });
   });
 });

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -44,7 +44,8 @@ export async function runMain(): Promise<void> {
   const processedState = loadProcessedState();
   const notifiedState = loadNotifiedState();
   const runId = new Date().toISOString();
-  const processedKeys = toProcessedKeySet(processedState);
+  const isReprocess = config.reprocess.enabled;
+  const processedKeys = isReprocess ? new Set<string>() : toProcessedKeySet(processedState);
   const progress = createProgressReporter();
   const summaryLines: string[] = [];
   const stageTimingsMs: Record<string, number> = {
@@ -66,9 +67,16 @@ export async function runMain(): Promise<void> {
   const notices = await collectNotices(config.apiKey, processedKeys, progress.report, {
     concurrency: config.performance.collectConcurrency,
     keepAlive: config.performance.httpKeepAlive,
+    lookbackMonths: config.reprocess.lookbackMonths,
   });
   stageTimingsMs.collect = Date.now() - stageStartedAt;
   summaryLines.push(`📦 처리 대상 공고 ${notices.length}건`);
+  if (isReprocess) {
+    summaryLines.push(`🔁 재처리 모드: 최근 ${config.reprocess.lookbackMonths}개월, 상한 ${config.reprocess.maxNotifications}건`);
+    if (config.reprocess.dryRun) {
+      summaryLines.push("🧪 재처리 dry-run: Slack 전송/상태 저장 생략");
+    }
+  }
 
   if (notices.length === 0) {
     stageTimingsMs.total = Date.now() - startedAt;
@@ -183,15 +191,29 @@ export async function runMain(): Promise<void> {
   stageStartedAt = Date.now();
   const matched = filterNotices(parsedSuccess, config.user);
   stageTimingsMs.filter = Date.now() - stageStartedAt;
+  const limitedMatched = isReprocess
+    ? matched.slice(0, config.reprocess.maxNotifications)
+    : matched;
+  const remainingForManual = isReprocess
+    ? Math.max(config.reprocess.maxNotifications - limitedMatched.length, 0)
+    : manualReviewNotices.length;
+  const limitedManualReviewNotices = isReprocess
+    ? manualReviewNotices.slice(0, remainingForManual)
+    : manualReviewNotices;
   progress.report({
     phase: "filter",
     current: 1,
     total: 1,
     percent: 100,
-    message: `조건충족 ${matched.length}건, 수동확인 ${manualReviewNotices.length}건`,
+    message: `조건충족 ${limitedMatched.length}건, 수동확인 ${limitedManualReviewNotices.length}건`,
   });
-  summaryLines.push(`✅ 조건 충족 공고 ${matched.length}건`);
-  summaryLines.push(`🟠 수동 확인 필요 공고 ${manualReviewNotices.length}건`);
+  summaryLines.push(`✅ 조건 충족 공고 ${limitedMatched.length}건`);
+  summaryLines.push(`🟠 수동 확인 필요 공고 ${limitedManualReviewNotices.length}건`);
+  if (isReprocess && (matched.length > limitedMatched.length || manualReviewNotices.length > limitedManualReviewNotices.length)) {
+    summaryLines.push(
+      `✂️ 재처리 상한으로 제외: 조건충족 ${matched.length - limitedMatched.length}건, 수동확인 ${manualReviewNotices.length - limitedManualReviewNotices.length}건`,
+    );
+  }
 
   const statusCounts: Record<NoticeApplicationStatus, number> = {
     upcoming: 0,
@@ -200,27 +222,36 @@ export async function runMain(): Promise<void> {
     unknown: 0,
   };
 
-  for (const notice of matched) {
+  for (const notice of limitedMatched) {
     statusCounts[normalizeApplicationStatus(notice.applicationStatus)] += 1;
   }
 
   statusSummary = `📌 접수상태(접수중/접수예정/마감/미확인): ${statusCounts.open}/${statusCounts.upcoming}/${statusCounts.closed}/${statusCounts.unknown}`;
 
-  if (matched.length > 0 || manualReviewNotices.length > 0) {
+  if (limitedMatched.length > 0 || limitedManualReviewNotices.length > 0) {
     stageStartedAt = Date.now();
-    await sendSlackNotification(
-      config.slackWebhookUrl,
-      matched,
-      config.user,
-      runId,
-      progress.report,
-      manualReviewNotices,
-      { keepAlive: config.performance.httpKeepAlive },
-    );
-    stageTimingsMs.notify = Date.now() - stageStartedAt;
-    markNotifiedNotices(notifiedState, matched, runId);
-    saveNotifiedState(notifiedState);
-    summaryLines.push(`📨 Slack 알림 전송 ${matched.length}건, 수동 확인 알림 ${manualReviewNotices.length}건`);
+    if (config.reprocess.dryRun) {
+      stageTimingsMs.notify = Date.now() - stageStartedAt;
+      summaryLines.push(`📨 Slack 알림 예정 ${limitedMatched.length}건, 수동 확인 예정 ${limitedManualReviewNotices.length}건 (dry-run)`);
+    } else {
+      await sendSlackNotification(
+        config.slackWebhookUrl,
+        limitedMatched,
+        config.user,
+        runId,
+        progress.report,
+        limitedManualReviewNotices,
+        {
+          keepAlive: config.performance.httpKeepAlive,
+          includeFilterSummary: true,
+          isReprocess,
+        },
+      );
+      stageTimingsMs.notify = Date.now() - stageStartedAt;
+      markNotifiedNotices(notifiedState, limitedMatched, runId);
+      saveNotifiedState(notifiedState);
+      summaryLines.push(`📨 Slack 알림 전송 ${limitedMatched.length}건, 수동 확인 알림 ${limitedManualReviewNotices.length}건`);
+    }
   } else {
     summaryLines.push("📨 Slack 알림 전송 없음");
   }
@@ -230,8 +261,10 @@ export async function runMain(): Promise<void> {
   if (failedPanIdSet.size > 0) {
     warningMessage = `⚠ 파싱 실패 ${failedPanIdSet.size}건은 processed 상태로 기록하지 않습니다.`;
   }
-  markProcessedNotices(processedState, processedTargets);
-  saveProcessedState(processedState);
+  if (!config.reprocess.dryRun) {
+    markProcessedNotices(processedState, processedTargets);
+    saveProcessedState(processedState);
+  }
 
   progress.complete();
   progress.flush();

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -37,6 +37,29 @@ export function selectProcessedNotices(
   return notices.filter((notice) => !candidatePanIds.has(notice.panId) || !failedPanIds.has(notice.panId));
 }
 
+export function isReprocessDryRunMode(isReprocess: boolean, dryRun: boolean): boolean {
+  return isReprocess && dryRun;
+}
+
+export function buildCollectOptions(
+  isReprocess: boolean,
+  performance: { collectConcurrency: number; httpKeepAlive: boolean },
+  lookbackMonths: number,
+): { concurrency: number; keepAlive: boolean; lookbackMonths?: number } {
+  if (isReprocess) {
+    return {
+      concurrency: performance.collectConcurrency,
+      keepAlive: performance.httpKeepAlive,
+      lookbackMonths,
+    };
+  }
+
+  return {
+    concurrency: performance.collectConcurrency,
+    keepAlive: performance.httpKeepAlive,
+  };
+}
+
 export async function runMain(): Promise<void> {
   const chalk = (await import("chalk")).default;
   loadEnv();
@@ -45,6 +68,7 @@ export async function runMain(): Promise<void> {
   const notifiedState = loadNotifiedState();
   const runId = new Date().toISOString();
   const isReprocess = config.reprocess.enabled;
+  const isReprocessDryRun = isReprocessDryRunMode(isReprocess, config.reprocess.dryRun);
   const processedKeys = isReprocess ? new Set<string>() : toProcessedKeySet(processedState);
   const progress = createProgressReporter();
   const summaryLines: string[] = [];
@@ -64,16 +88,17 @@ export async function runMain(): Promise<void> {
   let warningMessage: string | null = null;
 
   let stageStartedAt = Date.now();
-  const notices = await collectNotices(config.apiKey, processedKeys, progress.report, {
-    concurrency: config.performance.collectConcurrency,
-    keepAlive: config.performance.httpKeepAlive,
-    lookbackMonths: config.reprocess.lookbackMonths,
-  });
+  const notices = await collectNotices(
+    config.apiKey,
+    processedKeys,
+    progress.report,
+    buildCollectOptions(isReprocess, config.performance, config.reprocess.lookbackMonths),
+  );
   stageTimingsMs.collect = Date.now() - stageStartedAt;
   summaryLines.push(`📦 처리 대상 공고 ${notices.length}건`);
   if (isReprocess) {
     summaryLines.push(`🔁 재처리 모드: 최근 ${config.reprocess.lookbackMonths}개월, 상한 ${config.reprocess.maxNotifications}건`);
-    if (config.reprocess.dryRun) {
+    if (isReprocessDryRun) {
       summaryLines.push("🧪 재처리 dry-run: Slack 전송/상태 저장 생략");
     }
   }
@@ -230,7 +255,7 @@ export async function runMain(): Promise<void> {
 
   if (limitedMatched.length > 0 || limitedManualReviewNotices.length > 0) {
     stageStartedAt = Date.now();
-    if (config.reprocess.dryRun) {
+    if (isReprocessDryRun) {
       stageTimingsMs.notify = Date.now() - stageStartedAt;
       summaryLines.push(`📨 Slack 알림 예정 ${limitedMatched.length}건, 수동 확인 예정 ${limitedManualReviewNotices.length}건 (dry-run)`);
     } else {
@@ -261,7 +286,7 @@ export async function runMain(): Promise<void> {
   if (failedPanIdSet.size > 0) {
     warningMessage = `⚠ 파싱 실패 ${failedPanIdSet.size}건은 processed 상태로 기록하지 않습니다.`;
   }
-  if (!config.reprocess.dryRun) {
+  if (!isReprocessDryRun) {
     markProcessedNotices(processedState, processedTargets);
     saveProcessedState(processedState);
   }

--- a/src/entities/notice/model/types.ts
+++ b/src/entities/notice/model/types.ts
@@ -20,7 +20,10 @@ export interface SupplyItem {
   type: string;
   area: number;
   count: number;
-  address?: string | null;   // 신규: 단지 주소 (API/PDF에서 제공 시)
+  address?: string | null;   // 단지 주소 (API/PDF에서 제공 시)
+  areaSource?: "DDO_AR" | "HTY_DS_NM" | "UNKNOWN";
+  countSource?: "NOW_HSH_CNT" | "GNR_SPL_RMNO" | "UNKNOWN";
+  rawTypeText?: string;
 }
 
 export interface ParsedConditions {

--- a/src/features/collect-notices/collect-notices.test.ts
+++ b/src/features/collect-notices/collect-notices.test.ts
@@ -20,6 +20,19 @@ describe("extractItems", () => {
     expect(extractItems(body)[0].PAN_ID).toBe("A001");
   });
 
+  it("헤더 배열(*Nm)보다 실데이터 배열을 우선한다", () => {
+    const body = [
+      {
+        dsList01Nm: [{ HTY_DS_NM: "주택유형", GNR_SPL_RMNO: "공급호수" }],
+        dsList01: [{ HTY_DS_NM: "전용59㎡", GNR_SPL_RMNO: "2" }],
+      },
+    ];
+
+    const result = extractItems(body);
+    expect(result).toHaveLength(1);
+    expect(result[0].HTY_DS_NM).toBe("전용59㎡");
+  });
+
   it("빈 배열이면 빈 배열 반환", () => {
     expect(extractItems([])).toEqual([]);
   });

--- a/src/features/collect-notices/model/collect-notices.ts
+++ b/src/features/collect-notices/model/collect-notices.ts
@@ -11,12 +11,18 @@ const PAGE_SIZE = 100;
 const MAX_PAGE = 10;
 
 type JsonObject = Record<string, unknown>;
+type SupplyAreaSource = SupplyItem["areaSource"];
+type SupplyCountSource = SupplyItem["countSource"];
 
 interface NoticeDetailInfo {
   pdfUrl: string | null;
   applicationStartDate: string | null;
   applicationEndDate: string | null;
   applicationStatus: NoticeApplicationStatus;
+}
+
+interface ExtractItemsOptions {
+  preferredKeys?: string[];
 }
 
 function emitCollectProgress(
@@ -213,10 +219,23 @@ export function classifyApplicationStatus(
   return listPhase;
 }
 
-export function extractItems(body: unknown): Record<string, unknown>[] {
+function isMetaArrayKey(key: string): boolean {
+  if (key === "dsSch" || key === "resHeader") {
+    return true;
+  }
+  if (key.endsWith("Nm")) {
+    return true;
+  }
+
+  return false;
+}
+
+export function extractItems(body: unknown, options?: ExtractItemsOptions): Record<string, unknown>[] {
   if (!Array.isArray(body)) {
     return [];
   }
+
+  const candidates: Array<{ key: string; items: Record<string, unknown>[] }> = [];
 
   for (const chunk of body) {
     if (!isJsonObject(chunk)) {
@@ -224,16 +243,33 @@ export function extractItems(body: unknown): Record<string, unknown>[] {
     }
 
     for (const [key, value] of Object.entries(chunk)) {
-      if (key === "dsSch" || key === "resHeader") {
-        continue;
-      }
-
       if (!Array.isArray(value)) {
         continue;
       }
 
-      return value.filter(isJsonObject);
+      candidates.push({
+        key,
+        items: value.filter(isJsonObject),
+      });
     }
+  }
+
+  const preferredKeys = options?.preferredKeys ?? [];
+  for (const preferredKey of preferredKeys) {
+    const preferred = candidates.find((candidate) => candidate.key === preferredKey && candidate.items.length > 0);
+    if (preferred) {
+      return preferred.items;
+    }
+  }
+
+  const primary = candidates.find((candidate) => !isMetaArrayKey(candidate.key) && candidate.items.length > 0);
+  if (primary) {
+    return primary.items;
+  }
+
+  const fallback = candidates.find((candidate) => candidate.items.length > 0);
+  if (fallback) {
+    return fallback.items;
   }
 
   return [];
@@ -304,10 +340,14 @@ function buildDetailParams(item: Record<string, unknown>, panId: string): Record
   };
 }
 
-async function fetchNoticeList(apiKey: string, onProgress?: ProgressReporter): Promise<Record<string, unknown>[]> {
+async function fetchNoticeList(
+  apiKey: string,
+  onProgress?: ProgressReporter,
+  lookbackMonths = 6,
+): Promise<Record<string, unknown>[]> {
   const today = new Date();
   const lookback = new Date(today);
-  lookback.setMonth(lookback.getMonth() - 6);
+  lookback.setMonth(lookback.getMonth() - lookbackMonths);
 
   const todayYmd = toYmdNumber(formatApiDate(today)) ?? 0;
   const startDate = formatApiDate(lookback);
@@ -447,22 +487,124 @@ async function fetchSupplyInfo(
   const url = buildApiUrl(SUPPLY_URL, apiKey, buildDetailParams(item, panId));
   const { status, body } = await getWithAgent(url, agent);
   assertSuccessStatus(status, url, body);
-  const items = extractItems(body);
+  const items = extractItems(body, { preferredKeys: ["dsList01", "dsList", "dsList02"] });
 
-  return items.map((supply) => ({
-    type: toString(supply.HTY_NNA),
-    area: toNumber(supply.DDO_AR),
-    count: Math.trunc(toNumber(supply.NOW_HSH_CNT)),
-  }));
+  return items
+    .filter((supply) => !isSupplyHeaderRow(supply))
+    .map((supply) => {
+      const { area, source: areaSource } = parseSupplyArea(supply);
+      const { count, source: countSource } = parseSupplyCount(supply);
+      const rawTypeText = toString(supply.HTY_DS_NM).trim() || undefined;
+      const type = parseSupplyType(supply, rawTypeText);
+      const address = parseSupplyAddress(supply);
+
+      return {
+        type,
+        area,
+        count,
+        address,
+        areaSource,
+        countSource,
+        rawTypeText,
+      };
+    });
+}
+
+function isSupplyHeaderRow(supply: Record<string, unknown>): boolean {
+  const type = toString(supply.HTY_DS_NM).trim();
+  const count = toString(supply.GNR_SPL_RMNO).trim();
+  const area = toString(supply.DDO_AR).trim();
+  const address = toString(supply.LTR_UNT_NM).trim();
+  return (
+    type === "주택유형"
+    || count === "공급호수"
+    || area === "전용면적"
+    || address === "상세지역"
+  );
+}
+
+function parseAreaFromTypeText(rawTypeText: string): number {
+  const match = rawTypeText.match(/(\d+(?:\.\d+)?)/);
+  if (!match) {
+    return 0;
+  }
+
+  const parsed = Number.parseFloat(match[1]);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function parseSupplyArea(supply: Record<string, unknown>): { area: number; source: SupplyAreaSource } {
+  const areaFromDdoAr = toNumber(supply.DDO_AR);
+  if (areaFromDdoAr > 0) {
+    return { area: areaFromDdoAr, source: "DDO_AR" };
+  }
+
+  const rawTypeText = toString(supply.HTY_DS_NM).trim();
+  const areaFromType = parseAreaFromTypeText(rawTypeText);
+  if (areaFromType > 0) {
+    return { area: areaFromType, source: "HTY_DS_NM" };
+  }
+
+  return { area: 0, source: "UNKNOWN" };
+}
+
+function parseSupplyCount(supply: Record<string, unknown>): { count: number; source: SupplyCountSource } {
+  const countFromNow = Math.trunc(toNumber(supply.NOW_HSH_CNT));
+  if (countFromNow > 0) {
+    return { count: countFromNow, source: "NOW_HSH_CNT" };
+  }
+
+  const countFromGeneral = Math.trunc(toNumber(supply.GNR_SPL_RMNO));
+  if (countFromGeneral > 0) {
+    return { count: countFromGeneral, source: "GNR_SPL_RMNO" };
+  }
+
+  return { count: 0, source: "UNKNOWN" };
+}
+
+function parseSupplyType(supply: Record<string, unknown>, rawTypeText: string | undefined): string {
+  const directType = toString(supply.HTY_NNA).trim();
+  if (directType) {
+    return directType;
+  }
+
+  if (rawTypeText) {
+    const numberMatch = rawTypeText.match(/(\d+(?:\.\d+)?)/);
+    if (numberMatch) {
+      return numberMatch[1];
+    }
+    return rawTypeText;
+  }
+
+  return "미상";
+}
+
+function parseSupplyAddress(supply: Record<string, unknown>): string | null {
+  const unit = toString(supply.LTR_UNT_NM).trim();
+  const region = toString(supply.SBD_CNP_NM).trim();
+  if (unit && region && !unit.includes(region)) {
+    return `${region} ${unit}`.trim();
+  }
+
+  if (unit) {
+    return unit;
+  }
+
+  if (region) {
+    return region;
+  }
+
+  return null;
 }
 
 export async function collectNotices(
   apiKey: string,
   processedKeys: Set<string>,
   onProgress?: ProgressReporter,
-  options?: { concurrency?: number; keepAlive?: boolean },
+  options?: { concurrency?: number; keepAlive?: boolean; lookbackMonths?: number },
 ): Promise<Notice[]> {
-  const rawItems = await fetchNoticeList(apiKey, onProgress);
+  const lookbackMonths = Math.max(1, Math.floor(options?.lookbackMonths ?? 6));
+  const rawItems = await fetchNoticeList(apiKey, onProgress, lookbackMonths);
   const total = rawItems.length;
   const concurrency = Math.max(1, Math.floor(options?.concurrency ?? 4));
   const keepAlive = options?.keepAlive ?? true;

--- a/src/features/notify-slack/model/send-slack-notification.ts
+++ b/src/features/notify-slack/model/send-slack-notification.ts
@@ -19,7 +19,12 @@ export interface ManualReviewNotice {
   reason: ManualReviewReason;
 }
 
-export type SlackHistoryMessageType = "batch_header" | "notice" | "manual_review_header" | "manual_review_notice";
+export type SlackHistoryMessageType =
+  | "batch_header"
+  | "filter_summary"
+  | "notice"
+  | "manual_review_header"
+  | "manual_review_notice";
 
 export interface SlackHistoryRecord {
   timestamp: string;
@@ -43,6 +48,12 @@ interface SlackHistoryRecordInput {
   httpStatus: number | null;
   errorMessage: string | null;
   nowIso?: string;
+}
+
+interface SendSlackNotificationOptions {
+  keepAlive?: boolean;
+  includeFilterSummary?: boolean;
+  isReprocess?: boolean;
 }
 
 const HOUSING_TYPE_CODE_LABEL: Record<string, string> = {
@@ -95,9 +106,10 @@ function formatBucketTitle(bucket: SlackNoticeBucket): string {
   return "❔ 상태확인필요";
 }
 
-function buildBatchHeader(bucket: SlackNoticeBucket, count: number): SlackMessage {
+function buildBatchHeader(bucket: SlackNoticeBucket, count: number, isReprocess: boolean): SlackMessage {
+  const prefix = isReprocess ? "📣 *LH 공고 알림 (재처리)*" : "📣 *LH 공고 알림*";
   return {
-    text: `📣 *LH 공고 알림* | *${formatBucketTitle(bucket)}* ${count}건`,
+    text: `${prefix} | *${formatBucketTitle(bucket)}* ${count}건`,
   };
 }
 
@@ -274,6 +286,34 @@ function formatNotes(notes: string | null): string {
   return lines.join("\n");
 }
 
+function formatAmountLimit(value: number): string {
+  if (value <= 0) {
+    return "제한 없음";
+  }
+
+  return `${value.toLocaleString("ko-KR")}만원 이하`;
+}
+
+function buildFilterSummaryMessage(user: UserProfile, isReprocess: boolean): SlackMessage {
+  const regions = user.regions.length > 0 ? user.regions.join(", ") : "제한 없음";
+  const districts = user.districts.length > 0 ? user.districts.join(", ") : "제한 없음";
+  const housingTypes = user.housingTypes.length > 0 ? user.housingTypes.join(", ") : "제한 없음";
+  const areaRange = `${user.minArea}㎡ ~ ${user.maxArea}㎡`;
+  const prefix = isReprocess ? "🔁 *재처리 모드* 적용 필터" : "🎯 *적용 필터*";
+
+  return {
+    text: [
+      `${prefix}`,
+      `• 지역: ${regions}`,
+      `• 선호구: ${districts}`,
+      `• 공고유형 코드: ${housingTypes}`,
+      `• 면적: ${areaRange}`,
+      `• 보증금: ${formatAmountLimit(user.maxDeposit)}`,
+      `• 월임대료: ${formatAmountLimit(user.maxRent)}`,
+    ].join("\n"),
+  };
+}
+
 export function groupNoticesByStatus(notices: ParsedNotice[]): Record<SlackNoticeBucket, ParsedNotice[]> {
   const grouped: Record<SlackNoticeBucket, ParsedNotice[]> = {
     open: [],
@@ -307,11 +347,18 @@ export function formatSlackMessage(
   preferredDistricts: string[],
 ): SlackMessage {
   const supplyHighlights = extractSupplyHighlights(notice.conditions.notes);
+  let hasMissingPrice = false;
+
+  const formatAreaLabel = (area: number): string => (area > 0 ? `${area}㎡` : "면적 미상");
+  const formatCountLabel = (count: number): string => (count > 0 ? `${count}세대` : "세대수 미상");
 
   const supplyLines = notice.supplyInfo
     .map((item) => {
       const deposit = notice.conditions.deposit[item.type] ?? "-";
       const rent = notice.conditions.rent[item.type] ?? "-";
+      if (deposit === "-" || rent === "-") {
+        hasMissingPrice = true;
+      }
       const preferred = preferredDistricts.length > 0 && item.address
         ? preferredDistricts.some((d) => item.address!.includes(d))
         : false;
@@ -319,9 +366,9 @@ export function formatSlackMessage(
 
       const addressLine = item.address
         ? `  ${item.address}${prefixMark}`
-        : `  ${item.type}형${prefixMark}`;
+        : `  ${item.type || "단지 정보 미상"}${prefixMark}`;
 
-      const priceLine = `    ${item.area}㎡ ${item.count}세대 | 보증금 ${deposit} / 월임대료 ${rent}`;
+      const priceLine = `    ${formatAreaLabel(item.area)} ${formatCountLabel(item.count)} | 보증금 ${deposit} / 월임대료 ${rent}`;
 
       let mapLine = "";
       if (item.address) {
@@ -365,8 +412,17 @@ export function formatSlackMessage(
 
   lines.push("", "📦 *공급 정보*", supplySection);
 
+  const noteChunks: string[] = [];
   if (notice.conditions.notes) {
-    lines.push("", "📝 *비고*", formatNotes(notice.conditions.notes));
+    noteChunks.push(notice.conditions.notes);
+  }
+  if (hasMissingPrice) {
+    noteChunks.push("가격 정보 미확인: 원천 API 미제공 또는 PDF/본문 정형 추출 불가");
+  }
+
+  const mergedNotes = noteChunks.length > 0 ? noteChunks.join("\n") : null;
+  if (mergedNotes) {
+    lines.push("", "📝 *비고*", formatNotes(mergedNotes));
   }
 
   lines.push("", `🆔 공고 ID: ${formatPanIdLink(notice.panId, notice.noticeUrl)}`);
@@ -506,14 +562,17 @@ export async function sendSlackNotification(
   runId: string,
   onProgress?: ProgressReporter,
   manualReviewNotices: ManualReviewNotice[] = [],
-  options?: { keepAlive?: boolean },
+  options?: SendSlackNotificationOptions,
 ): Promise<void> {
   const keepAlive = options?.keepAlive ?? true;
+  const includeFilterSummary = options?.includeFilterSummary ?? true;
+  const isReprocess = options?.isReprocess ?? false;
   const agent = keepAlive ? new https.Agent({ keepAlive: true }) : undefined;
   const grouped = groupNoticesByStatus(notices);
   const order: SlackNoticeBucket[] = ["open", "upcoming", "unknown"];
   const total = order.reduce((sum, bucket) => sum + grouped[bucket].length, 0) + manualReviewNotices.length;
   let current = 0;
+  let filterSummarySent = false;
 
   const emitProgress = (message: string): void => {
     if (!onProgress) {
@@ -539,7 +598,7 @@ export async function sendSlackNotification(
         continue;
       }
 
-      const batchHeader = buildBatchHeader(bucket, bucketNotices.length);
+      const batchHeader = buildBatchHeader(bucket, bucketNotices.length, isReprocess);
       try {
         const result = await postToSlack(webhookUrl, batchHeader, agent);
         tryAppendSlackHistory(
@@ -570,6 +629,42 @@ export async function sendSlackNotification(
           }),
         );
         throw error;
+      }
+
+      if (includeFilterSummary && !filterSummarySent) {
+        const filterSummary = buildFilterSummaryMessage(user, isReprocess);
+        try {
+          const result = await postToSlack(webhookUrl, filterSummary, agent);
+          tryAppendSlackHistory(
+            createSlackHistoryRecord({
+              runId,
+              panId: null,
+              messageType: "filter_summary",
+              applicationStatus: null,
+              payloadText: filterSummary.text,
+              status: "success",
+              httpStatus: result.statusCode,
+              errorMessage: null,
+            }),
+          );
+        } catch (error) {
+          const statusCode = error instanceof SlackPostError ? error.statusCode : null;
+          const message = error instanceof Error ? error.message : String(error);
+          tryAppendSlackHistory(
+            createSlackHistoryRecord({
+              runId,
+              panId: null,
+              messageType: "filter_summary",
+              applicationStatus: null,
+              payloadText: filterSummary.text,
+              status: "failed",
+              httpStatus: statusCode,
+              errorMessage: message,
+            }),
+          );
+          throw error;
+        }
+        filterSummarySent = true;
       }
 
       if (!onProgress) {
@@ -620,6 +715,42 @@ export async function sendSlackNotification(
     }
 
     if (manualReviewNotices.length > 0) {
+      if (includeFilterSummary && !filterSummarySent) {
+        const filterSummary = buildFilterSummaryMessage(user, isReprocess);
+        try {
+          const result = await postToSlack(webhookUrl, filterSummary, agent);
+          tryAppendSlackHistory(
+            createSlackHistoryRecord({
+              runId,
+              panId: null,
+              messageType: "filter_summary",
+              applicationStatus: null,
+              payloadText: filterSummary.text,
+              status: "success",
+              httpStatus: result.statusCode,
+              errorMessage: null,
+            }),
+          );
+        } catch (error) {
+          const statusCode = error instanceof SlackPostError ? error.statusCode : null;
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          tryAppendSlackHistory(
+            createSlackHistoryRecord({
+              runId,
+              panId: null,
+              messageType: "filter_summary",
+              applicationStatus: null,
+              payloadText: filterSummary.text,
+              status: "failed",
+              httpStatus: statusCode,
+              errorMessage,
+            }),
+          );
+          throw error;
+        }
+        filterSummarySent = true;
+      }
+
       const manualReviewHeader = buildManualReviewHeader(manualReviewNotices.length);
       try {
         const result = await postToSlack(webhookUrl, manualReviewHeader, agent);

--- a/src/features/notify-slack/notify-slack.test.ts
+++ b/src/features/notify-slack/notify-slack.test.ts
@@ -132,6 +132,32 @@ describe("formatSlackMessage", () => {
     expect(message.text).toContain("전용면적");
     expect(message.text).toContain("분양가격");
   });
+
+  it("면적/세대수가 0이면 미상으로 표시한다", () => {
+    const message = formatSlackMessage({
+      ...notice,
+      supplyInfo: [{ type: "26", area: 0, count: 0 }],
+    }, [], []);
+
+    expect(message.text).toContain("면적 미상");
+    expect(message.text).toContain("세대수 미상");
+    expect(message.text).not.toContain("0㎡ 0세대");
+  });
+
+  it("가격 정보가 '-'이면 비고에 미확인 사유를 추가한다", () => {
+    const message = formatSlackMessage({
+      ...notice,
+      conditions: {
+        ...notice.conditions,
+        notes: null,
+        deposit: {},
+        rent: {},
+      },
+    }, [], []);
+
+    expect(message.text).toContain("📝 *비고*");
+    expect(message.text).toContain("가격 정보 미확인");
+  });
 });
 
 describe("formatSlackMessage — 판정 결과 포함", () => {

--- a/src/shared/config/app-config.test.ts
+++ b/src/shared/config/app-config.test.ts
@@ -51,6 +51,10 @@ describe("loadConfig", () => {
     expect(config.performance.parseConcurrency).toBe(2);
     expect(config.performance.httpKeepAlive).toBe(true);
     expect(config.performance.timingSummary).toBe(true);
+    expect(config.reprocess.enabled).toBe(false);
+    expect(config.reprocess.dryRun).toBe(false);
+    expect(config.reprocess.lookbackMonths).toBe(6);
+    expect(config.reprocess.maxNotifications).toBe(50);
   });
 
   it("필수 환경변수 누락 시 오류를 던진다", () => {
@@ -120,11 +124,28 @@ describe("loadConfig", () => {
       expect(config.performance.parseConcurrency).toBe(2);
       expect(config.performance.httpKeepAlive).toBe(true);
       expect(config.performance.timingSummary).toBe(true);
+      expect(config.reprocess.enabled).toBe(false);
+      expect(config.reprocess.dryRun).toBe(false);
+      expect(config.reprocess.lookbackMonths).toBe(6);
+      expect(config.reprocess.maxNotifications).toBe(50);
     });
 
     it("COLLECT_CONCURRENCY가 0 이하이면 오류를 던진다", () => {
       process.env.COLLECT_CONCURRENCY = "0";
       expect(() => loadConfig()).toThrow("COLLECT_CONCURRENCY");
+    });
+
+    it("재처리 관련 env를 읽는다", () => {
+      process.env.REPROCESS_ENABLED = "true";
+      process.env.REPROCESS_DRY_RUN = "true";
+      process.env.REPROCESS_LOOKBACK_MONTHS = "3";
+      process.env.REPROCESS_MAX_NOTIFICATIONS = "20";
+
+      const config = loadConfig();
+      expect(config.reprocess.enabled).toBe(true);
+      expect(config.reprocess.dryRun).toBe(true);
+      expect(config.reprocess.lookbackMonths).toBe(3);
+      expect(config.reprocess.maxNotifications).toBe(20);
     });
   });
 });

--- a/src/shared/config/app-config.ts
+++ b/src/shared/config/app-config.ts
@@ -14,6 +14,12 @@ export interface AppConfig {
     httpKeepAlive: boolean;
     timingSummary: boolean;
   };
+  reprocess: {
+    enabled: boolean;
+    dryRun: boolean;
+    lookbackMonths: number;
+    maxNotifications: number;
+  };
 }
 
 function requireEnv(key: string): string {
@@ -132,12 +138,23 @@ export function loadConfig(): AppConfig {
     timingSummary: parseBooleanValue(optionalEnv("PERF_TIMING_SUMMARY", "true"), "PERF_TIMING_SUMMARY"),
   };
 
+  const reprocess = {
+    enabled: parseBooleanValue(optionalEnv("REPROCESS_ENABLED", "false"), "REPROCESS_ENABLED"),
+    dryRun: parseBooleanValue(optionalEnv("REPROCESS_DRY_RUN", "false"), "REPROCESS_DRY_RUN"),
+    lookbackMonths: parsePositiveIntValue(optionalEnv("REPROCESS_LOOKBACK_MONTHS", "6"), "REPROCESS_LOOKBACK_MONTHS"),
+    maxNotifications: parsePositiveIntValue(
+      optionalEnv("REPROCESS_MAX_NOTIFICATIONS", "50"),
+      "REPROCESS_MAX_NOTIFICATIONS",
+    ),
+  };
+
   return {
     apiKey,
     anthropicKey,
     slackWebhookUrl,
     user,
     performance,
+    reprocess,
   };
 }
 


### PR DESCRIPTION
## 작업 내용
- 공급 API 응답에서 헤더 배열(`*Nm`) 대신 실데이터 배열을 우선 선택하도록 개선
- SPL_INF_TP_CD=130 스키마 fallback 매핑(면적/세대수/주소) 추가
- Slack 메시지에 적용 필터 요약 섹션 추가
- 공급값 미상 표기 개선(0값 노출 방지) 및 가격 `-` 사유 비고 자동 추가
- 재처리 모드 환경변수(REPROCESS_*) 및 main 흐름(dry-run/상한/상태 처리) 추가

## 테스트
- npx jest

## 관련 이슈
- close #28
